### PR TITLE
feat: export helpers via ./helpers sub-path

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,8 @@
   "name": "@nshiab/simple-data-analysis-core",
   "version": "0.0.9",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./helpers": "./src/helpers/index.ts"
   },
   "tasks": {
     "all-tests": "deno fmt --check && deno lint && deno check src/index.ts && deno publish --allow-dirty --dry-run && rm -rf test/output && deno test -A --fail-fast && deno task llm",

--- a/src/helpers/cleanSQL.ts
+++ b/src/helpers/cleanSQL.ts
@@ -1,4 +1,4 @@
-export default function cleanSQL(query: string) {
+export default function cleanSQL(query: string): string {
   // First pass
   let cleaned = query
     .replace(/ && /g, " AND ")

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Helper utilities for Simple Data Analysis Core.
+ *
+ * These helpers are exported for reuse by `simple-data-analysis` and other
+ * consumers, removing the need to duplicate their implementations.
+ *
+ * @example
+ * ```ts
+ * import { cleanSQL, parseValue, stringToArray } from "@nshiab/simple-data-analysis-core/helpers";
+ *
+ * const sql = cleanSQL("name == 'John' && age > 30");
+ * const literal = parseValue("hello");
+ * const arr = stringToArray("single");
+ * ```
+ */
+
+export { default as cleanSQL } from "./cleanSQL.ts";
+export { default as convertForJS } from "./convertForJS.ts";
+export { default as createDirectory } from "./createDirectory.ts";
+export { default as mergeOptions } from "./mergeOptions.ts";
+export { default as parseValue } from "./parseValue.ts";
+export { default as queryDB } from "./queryDB.ts";
+export { default as runQuery } from "./runQuery.ts";
+export { default as stringToArray } from "./stringToArray.ts";

--- a/src/helpers/parseValue.ts
+++ b/src/helpers/parseValue.ts
@@ -1,4 +1,4 @@
-export default function parseValue(value: unknown) {
+export default function parseValue(value: unknown): string | boolean | number {
   if (Number.isNaN(value) || value === undefined || value === null) {
     return "NULL";
   } else if (value instanceof Date) {

--- a/src/helpers/stringToArray.ts
+++ b/src/helpers/stringToArray.ts
@@ -1,4 +1,4 @@
-export default function stringToArray(argument: string | string[]) {
+export default function stringToArray(argument: string | string[]): string[] {
   if (Array.isArray(argument)) {
     return argument;
   } else if (typeof argument === "string") {


### PR DESCRIPTION
## Summary

Export 8 internal helpers through a new `./helpers` sub-path export, removing the need for `simple-data-analysis` to maintain duplicate copies.

## Changes

- **New:** `src/helpers/index.ts` — Barrel file exporting 8 helpers:
  - `cleanSQL` — Normalize JS-style operators to SQL
  - `convertForJS` — Convert DuckDB row types to JS types
  - `createDirectory` — Recursively create directories
  - `mergeOptions` — Merge method options with instance defaults
  - `parseValue` — Serialize JS values to SQL literals
  - `queryDB` — Execute SQL queries with debug logging
  - `runQuery` — Low-level DuckDB query execution
  - `stringToArray` — Coerce string/string[] into string[]

- **Updated:** `deno.json` — Added `"./helpers"` sub-path export
- **Fixed:** Added explicit return types to `cleanSQL`, `parseValue`, `stringToArray` (required by JSR public API lint rules)

## Usage

Consumers can now import helpers via:

```ts
import { cleanSQL, parseValue, stringToArray } from "@nshiab/simple-data-analysis-core/helpers";
```

## Notes

- Only the 8 duplicated helpers are exported (not all internal helpers)
- No breaking changes for existing consumers — purely additive exports
- `simple-data-analysis` can now remove its local copies of these 8 helpers

Closes #18