### PR TITLE
Remove unused helpers from public exports

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -6,19 +6,15 @@
  *
  * @example
  * ```ts
- * import { cleanSQL, parseValue, stringToArray } from "@nshiab/simple-data-analysis-core/helpers";
+ * import { parseValue, stringToArray } from "@nshiab/simple-data-analysis-core/helpers";
  *
- * const sql = cleanSQL("name == 'John' && age > 30");
  * const literal = parseValue("hello");
  * const arr = stringToArray("single");
  * ```
  */
 
-export { default as cleanSQL } from "./cleanSQL.ts";
-export { default as convertForJS } from "./convertForJS.ts";
 export { default as createDirectory } from "./createDirectory.ts";
 export { default as mergeOptions } from "./mergeOptions.ts";
 export { default as parseValue } from "./parseValue.ts";
 export { default as queryDB } from "./queryDB.ts";
-export { default as runQuery } from "./runQuery.ts";
 export { default as stringToArray } from "./stringToArray.ts";


### PR DESCRIPTION
Closes #20

## Summary

Removes , , and  from the public helpers export surface (). These helpers are not consumed by any external consumer (e.g., ).

## Notes

The underlying files (, , ) are **kept** as internal modules because they are still used internally:
-  — used by 
-  — used by , , and 
-  — used by 

## Changes

- Removed 3 exports from 
- Updated JSDoc example to remove  reference