### PR TITLE
feat: add pad() method to SimpleTable for string padding (LPAD/RPAD)

### DIFF
--- a/llm.md
+++ b/llm.md
@@ -2689,9 +2689,9 @@ await table.truncate("name", 10);
 
 Pads the strings in the specified column to a target length.
 
-Only string values are padded. `null` values remain `null`, and non-string
-values (other than `null`) are left unchanged. Strings longer than the target
-length are truncated to fit.
+The column must contain string (VARCHAR) values. An error is thrown if the
+column is of a different type. `null` values remain `null`. An error is thrown
+if any string value exceeds the target length.
 
 ##### Signature
 
@@ -2710,6 +2710,11 @@ async pad(column: string, length: number, options?: { side?: "start" | "end"; ch
 ##### Returns
 
 A promise that resolves when the padding operation is complete.
+
+##### Throws
+
+- **`Error`**: If the column is not of string (VARCHAR) type.
+- **`Error`**: If any string value in the column exceeds the target length.
 
 ##### Examples
 

--- a/llm.md
+++ b/llm.md
@@ -2687,21 +2687,21 @@ await table.truncate("name", 10);
 
 #### `pad`
 
-Pads the strings in the specified column to a target length.
+Pads the strings in the specified columns to a target length.
 
-The column must contain string (VARCHAR) values. An error is thrown if the
+The columns must contain string (VARCHAR) values. An error is thrown if any
 column is of a different type. `null` values remain `null`. An error is thrown
-if any string value exceeds the target length.
+if any string value exceeds the target length (no silent truncation).
 
 ##### Signature
 
 ```typescript
-async pad(column: string, length: number, options?: { side?: "start" | "end"; char?: string }): Promise<void>;
+async pad(columns: string | string[], length: number, options?: { side?: "start" | "end"; char?: string }): Promise<void>;
 ```
 
 ##### Parameters
 
-- **`column`**: The column name containing strings to be padded.
+- **`columns`**: The column name(s) containing strings to be padded.
 - **`length`**: The target length of the padded strings.
 - **`options`**: An optional object with configuration options:
 - **`options.side`**: Which side to pad. `'start'` (default) or `'end'`.
@@ -2713,8 +2713,8 @@ A promise that resolves when the padding operation is complete.
 
 ##### Throws
 
-- **`Error`**: If the column is not of string (VARCHAR) type.
-- **`Error`**: If any string value in the column exceeds the target length.
+- **`Error`**: If any column is not of string (VARCHAR) type.
+- **`Error`**: If any string value in any column exceeds the target length.
 
 ##### Examples
 
@@ -2731,8 +2731,8 @@ await table.pad("code", 5, { side: "end", char: " " });
 ```
 
 ```ts
-// Left-pad 'id' column to 5 characters with dashes
-await table.pad("id", 5, { side: "start", char: "-" });
+// Left-pad multiple columns to 5 characters with dashes
+await table.pad(["id", "code"], 5, { side: "start", char: "-" });
 // Result: '1' -> '----1', '23' -> '---23'
 ```
 

--- a/llm.md
+++ b/llm.md
@@ -2685,6 +2685,58 @@ await table.truncate("description", 50);
 await table.truncate("name", 10);
 ```
 
+#### `pad`
+
+Pads the strings in the specified column to a target length.
+
+Only string values are padded. `null` values remain `null`, and non-string
+values (other than `null`) are left unchanged. Strings longer than the target
+length are truncated to fit.
+
+##### Signature
+
+```typescript
+async pad(column: string, length: number, options?: { side?: "start" | "end"; char?: string }): Promise<void>;
+```
+
+##### Parameters
+
+- **`column`**: The column name containing strings to be padded.
+- **`length`**: The target length of the padded strings.
+- **`options`**: An optional object with configuration options:
+- **`options.side`**: Which side to pad. `'start'` (default) or `'end'`.
+- **`options.char`**: The character to use for padding. Defaults to `'0'`.
+
+##### Returns
+
+A promise that resolves when the padding operation is complete.
+
+##### Examples
+
+```ts
+// Left-pad 'id' column to 3 characters with zeros (default)
+await table.pad("id", 3);
+// Result: '1' -> '001', '23' -> '023', null -> null
+```
+
+```ts
+// Right-pad 'code' column to 5 characters with spaces
+await table.pad("code", 5, { side: "end", char: " " });
+// Result: '123' -> '123  ', '45' -> '45   ', null -> null
+```
+
+```ts
+// Left-pad 'id' column to 5 characters with dashes
+await table.pad("id", 5, { side: "start", char: "-" });
+// Result: '1' -> '----1', '23' -> '---23'
+```
+
+```ts
+// Padding with a longer fill string (DuckDB repeats/truncates as needed)
+await table.pad("code", 6, { side: "end", char: "ab" });
+// Result: '1' -> '1ababa', '23' -> '23abab'
+```
+
 #### `splitExtract`
 
 Splits strings in a specified column by a separator and extracts a substring at

--- a/llm.md
+++ b/llm.md
@@ -2690,8 +2690,8 @@ await table.truncate("name", 10);
 Pads the strings in the specified columns to a target length.
 
 The columns must contain string (VARCHAR) values. An error is thrown if any
-column is of a different type. `null` values remain `null`. An error is thrown
-if any string value exceeds the target length (no silent truncation).
+column is of a different type. `null` values remain `null`. Strings that already
+exceed the target length are truncated to that length.
 
 ##### Signature
 
@@ -2714,7 +2714,6 @@ A promise that resolves when the padding operation is complete.
 ##### Throws
 
 - **`Error`**: If any column is not of string (VARCHAR) type.
-- **`Error`**: If any string value in any column exceeds the target length.
 
 ##### Examples
 
@@ -2734,12 +2733,6 @@ await table.pad("code", 5, { side: "end", char: " " });
 // Left-pad multiple columns to 5 characters with dashes
 await table.pad(["id", "code"], 5, { side: "start", char: "-" });
 // Result: '1' -> '----1', '23' -> '---23'
-```
-
-```ts
-// Padding with a longer fill string (DuckDB repeats/truncates as needed)
-await table.pad("code", 6, { side: "end", char: "ab" });
-// Result: '1' -> '1ababa', '23' -> '23abab'
 ```
 
 #### `splitExtract`

--- a/llm.md
+++ b/llm.md
@@ -2690,13 +2690,13 @@ await table.truncate("name", 10);
 Pads the strings in the specified columns to a target length.
 
 The columns must contain string (VARCHAR) values. An error is thrown if any
-column is of a different type. `null` values remain `null`. Strings that already
-exceed the target length are truncated to that length.
+column is of a different type. `null` values remain `null`. If any string
+already exceeds the target length, an error is thrown (no silent truncation).
 
 ##### Signature
 
 ```typescript
-async pad(columns: string | string[], length: number, options?: { side?: "start" | "end"; char?: string }): Promise<void>;
+async pad(columns: string | string[], length: number, options?: { method?: "left" | "right"; char?: string }): Promise<void>;
 ```
 
 ##### Parameters
@@ -2704,7 +2704,7 @@ async pad(columns: string | string[], length: number, options?: { side?: "start"
 - **`columns`**: The column name(s) containing strings to be padded.
 - **`length`**: The target length of the padded strings.
 - **`options`**: An optional object with configuration options:
-- **`options.side`**: Which side to pad. `'start'` (default) or `'end'`.
+- **`options.method`**: Which side to pad. `'left'` (default) or `'right'`.
 - **`options.char`**: The character to use for padding. Defaults to `'0'`.
 
 ##### Returns
@@ -2714,6 +2714,7 @@ A promise that resolves when the padding operation is complete.
 ##### Throws
 
 - **`Error`**: If any column is not of string (VARCHAR) type.
+- **`Error`**: If any string value exceeds the target length.
 
 ##### Examples
 
@@ -2725,13 +2726,13 @@ await table.pad("id", 3);
 
 ```ts
 // Right-pad 'code' column to 5 characters with spaces
-await table.pad("code", 5, { side: "end", char: " " });
+await table.pad("code", 5, { method: "right", char: " " });
 // Result: '123' -> '123  ', '45' -> '45   ', null -> null
 ```
 
 ```ts
 // Left-pad multiple columns to 5 characters with dashes
-await table.pad(["id", "code"], 5, { side: "start", char: "-" });
+await table.pad(["id", "code"], 5, { method: "left", char: "-" });
 // Result: '1' -> '----1', '23' -> '---23'
 ```
 

--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -87,6 +87,7 @@ import getExtension from "../helpers/getExtension.ts";
 import getIdenticalColumns from "../helpers/getIdenticalColumns.ts";
 import capitalizeQuery from "../methods/capitalizeQuery.ts";
 import truncateQuery from "../methods/truncateQuery.ts";
+import padQuery from "../methods/padQuery.ts";
 import getProjectionParquet from "../helpers/getProjectionParquet.ts";
 import unifyColumns from "../helpers/unifyColumns.ts";
 import accumulateQuery from "../helpers/accumulateQuery.ts";
@@ -2781,6 +2782,65 @@ export default class SimpleTable extends Simple {
         table: this.name,
         method: "truncate()",
         parameters: { column, length },
+      }),
+    );
+  }
+
+  /**
+   * Pads the strings in the specified column to a target length.
+   *
+   * Only string values are padded. `null` values remain `null`, and non-string
+   * values (other than `null`) are left unchanged. Strings longer than the
+   * target length are truncated to fit.
+   *
+   * @param column - The column name containing strings to be padded.
+   * @param length - The target length of the padded strings.
+   * @param options - An optional object with configuration options:
+   * @param options.side - Which side to pad. `'start'` (default) or `'end'`.
+   * @param options.char - The character to use for padding. Defaults to `'0'`.
+   * @returns A promise that resolves when the padding operation is complete.
+   * @category Updating Data
+   *
+   * @example
+   * ```ts
+   * // Left-pad 'id' column to 3 characters with zeros (default)
+   * await table.pad("id", 3);
+   * // Result: '1' -> '001', '23' -> '023', null -> null
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Right-pad 'code' column to 5 characters with spaces
+   * await table.pad("code", 5, { side: "end", char: " " });
+   * // Result: '123' -> '123  ', '45' -> '45   ', null -> null
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Left-pad 'id' column to 5 characters with dashes
+   * await table.pad("id", 5, { side: "start", char: "-" });
+   * // Result: '1' -> '----1', '23' -> '---23'
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Padding with a longer fill string (DuckDB repeats/truncates as needed)
+   * await table.pad("code", 6, { side: "end", char: "ab" });
+   * // Result: '1' -> '1ababa', '23' -> '23abab'
+   * ```
+   */
+  async pad(
+    column: string,
+    length: number,
+    options: { side?: "start" | "end"; char?: string } = {},
+  ): Promise<void> {
+    await queryDB(
+      this,
+      padQuery(this.name, column, length, options),
+      mergeOptions(this, {
+        table: this.name,
+        method: "pad()",
+        parameters: { column, length, options },
       }),
     );
   }

--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -2790,8 +2790,8 @@ export default class SimpleTable extends Simple {
    * Pads the strings in the specified columns to a target length.
    *
    * The columns must contain string (VARCHAR) values. An error is thrown if any
-   * column is of a different type. `null` values remain `null`. An error is
-   * thrown if any string value exceeds the target length (no silent truncation).
+   * column is of a different type. `null` values remain `null`. Strings that
+   * already exceed the target length are truncated to that length.
    *
    * @param columns - The column name(s) containing strings to be padded.
    * @param length - The target length of the padded strings.
@@ -2800,7 +2800,6 @@ export default class SimpleTable extends Simple {
    * @param options.char - The character to use for padding. Defaults to `'0'`.
    * @returns A promise that resolves when the padding operation is complete.
    * @throws {Error} If any column is not of string (VARCHAR) type.
-   * @throws {Error} If any string value in any column exceeds the target length.
    * @category Updating Data
    *
    * @example
@@ -2823,13 +2822,6 @@ export default class SimpleTable extends Simple {
    * await table.pad(["id", "code"], 5, { side: "start", char: "-" });
    * // Result: '1' -> '----1', '23' -> '---23'
    * ```
-   *
-   * @example
-   * ```ts
-   * // Padding with a longer fill string (DuckDB repeats/truncates as needed)
-   * await table.pad("code", 6, { side: "end", char: "ab" });
-   * // Result: '1' -> '1ababa', '23' -> '23abab'
-   * ```
    */
   async pad(
     columns: string | string[],
@@ -2846,20 +2838,6 @@ export default class SimpleTable extends Simple {
           `The column "${column}" is of type ${
             allTypes[column]
           }. The pad() method only works with string (VARCHAR) columns. Please convert the column to string first with the .convert() method.`,
-        );
-      }
-    }
-
-    // Validate no string value exceeds the target length (using DuckDB for performance)
-    for (const column of columnList) {
-      const result = await this.sdb.customQuery(
-        `SELECT MAX(LENGTH("${column}")) as max_len FROM "${this.name}" WHERE "${column}" IS NOT NULL`,
-        { returnDataFrom: "query" },
-      ) as { max_len: number | null }[];
-      const maxLen = result[0]?.max_len ?? 0;
-      if (maxLen > length) {
-        throw new Error(
-          `Column "${column}" contains strings with length ${maxLen}, which exceeds the target length ${length}.`,
         );
       }
     }

--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -2787,20 +2787,20 @@ export default class SimpleTable extends Simple {
   }
 
   /**
-   * Pads the strings in the specified column to a target length.
+   * Pads the strings in the specified columns to a target length.
    *
-   * The column must contain string (VARCHAR) values. An error is thrown if the
+   * The columns must contain string (VARCHAR) values. An error is thrown if any
    * column is of a different type. `null` values remain `null`. An error is
-   * thrown if any string value exceeds the target length.
+   * thrown if any string value exceeds the target length (no silent truncation).
    *
-   * @param column - The column name containing strings to be padded.
+   * @param columns - The column name(s) containing strings to be padded.
    * @param length - The target length of the padded strings.
    * @param options - An optional object with configuration options:
    * @param options.side - Which side to pad. `'start'` (default) or `'end'`.
    * @param options.char - The character to use for padding. Defaults to `'0'`.
    * @returns A promise that resolves when the padding operation is complete.
-   * @throws {Error} If the column is not of string (VARCHAR) type.
-   * @throws {Error} If any string value in the column exceeds the target length.
+   * @throws {Error} If any column is not of string (VARCHAR) type.
+   * @throws {Error} If any string value in any column exceeds the target length.
    * @category Updating Data
    *
    * @example
@@ -2819,8 +2819,8 @@ export default class SimpleTable extends Simple {
    *
    * @example
    * ```ts
-   * // Left-pad 'id' column to 5 characters with dashes
-   * await table.pad("id", 5, { side: "start", char: "-" });
+   * // Left-pad multiple columns to 5 characters with dashes
+   * await table.pad(["id", "code"], 5, { side: "start", char: "-" });
    * // Result: '1' -> '----1', '23' -> '---23'
    * ```
    *
@@ -2832,37 +2832,45 @@ export default class SimpleTable extends Simple {
    * ```
    */
   async pad(
-    column: string,
+    columns: string | string[],
     length: number,
     options: { side?: "start" | "end"; char?: string } = {},
   ): Promise<void> {
-    // Validate column type is string
+    const columnList = stringToArray(columns);
+
+    // Validate all columns are string type
     const allTypes = await this.getTypes();
-    if (allTypes[column] !== "VARCHAR") {
-      throw new Error(
-        `The column "${column}" is of type ${
-          allTypes[column]
-        }. The pad() method only works with string (VARCHAR) columns. Please convert the column to string first with the .convert() method.`,
-      );
+    for (const column of columnList) {
+      if (allTypes[column] !== "VARCHAR") {
+        throw new Error(
+          `The column "${column}" is of type ${
+            allTypes[column]
+          }. The pad() method only works with string (VARCHAR) columns. Please convert the column to string first with the .convert() method.`,
+        );
+      }
     }
 
-    // Validate no string value exceeds the target length
-    const values = await this.getValues(column);
-    for (const val of values) {
-      if (val !== null && typeof val === "string" && val.length > length) {
+    // Validate no string value exceeds the target length (using DuckDB for performance)
+    for (const column of columnList) {
+      const result = await this.sdb.customQuery(
+        `SELECT MAX(LENGTH("${column}")) as max_len FROM "${this.name}" WHERE "${column}" IS NOT NULL`,
+        { returnDataFrom: "query" },
+      ) as { max_len: number | null }[];
+      const maxLen = result[0]?.max_len ?? 0;
+      if (maxLen > length) {
         throw new Error(
-          `The string "${val}" in column "${column}" has length ${val.length}, which exceeds the target length ${length}.`,
+          `Column "${column}" contains strings with length ${maxLen}, which exceeds the target length ${length}.`,
         );
       }
     }
 
     await queryDB(
       this,
-      padQuery(this.name, column, length, options),
+      padQuery(this.name, columnList, length, options),
       mergeOptions(this, {
         table: this.name,
         method: "pad()",
-        parameters: { column, length, options },
+        parameters: { columns, length, options },
       }),
     );
   }

--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -2790,16 +2790,17 @@ export default class SimpleTable extends Simple {
    * Pads the strings in the specified columns to a target length.
    *
    * The columns must contain string (VARCHAR) values. An error is thrown if any
-   * column is of a different type. `null` values remain `null`. Strings that
-   * already exceed the target length are truncated to that length.
+   * column is of a different type. `null` values remain `null`. If any string
+   * already exceeds the target length, an error is thrown (no silent truncation).
    *
    * @param columns - The column name(s) containing strings to be padded.
    * @param length - The target length of the padded strings.
    * @param options - An optional object with configuration options:
-   * @param options.side - Which side to pad. `'start'` (default) or `'end'`.
+   * @param options.method - Which side to pad. `'left'` (default) or `'right'`.
    * @param options.char - The character to use for padding. Defaults to `'0'`.
    * @returns A promise that resolves when the padding operation is complete.
    * @throws {Error} If any column is not of string (VARCHAR) type.
+   * @throws {Error} If any string value exceeds the target length.
    * @category Updating Data
    *
    * @example
@@ -2812,21 +2813,21 @@ export default class SimpleTable extends Simple {
    * @example
    * ```ts
    * // Right-pad 'code' column to 5 characters with spaces
-   * await table.pad("code", 5, { side: "end", char: " " });
+   * await table.pad("code", 5, { method: "right", char: " " });
    * // Result: '123' -> '123  ', '45' -> '45   ', null -> null
    * ```
    *
    * @example
    * ```ts
    * // Left-pad multiple columns to 5 characters with dashes
-   * await table.pad(["id", "code"], 5, { side: "start", char: "-" });
+   * await table.pad(["id", "code"], 5, { method: "left", char: "-" });
    * // Result: '1' -> '----1', '23' -> '---23'
    * ```
    */
   async pad(
     columns: string | string[],
     length: number,
-    options: { side?: "start" | "end"; char?: string } = {},
+    options: { method?: "left" | "right"; char?: string } = {},
   ): Promise<void> {
     const columnList = stringToArray(columns);
 
@@ -2838,6 +2839,26 @@ export default class SimpleTable extends Simple {
           `The column "${column}" is of type ${
             allTypes[column]
           }. The pad() method only works with string (VARCHAR) columns. Please convert the column to string first with the .convert() method.`,
+        );
+      }
+    }
+
+    // Pre-validation: check for strings exceeding target length
+    for (const column of columnList) {
+      const overflowResult = await queryDB(
+        this,
+        `SELECT COUNT(*) AS cnt FROM "${this.name}" WHERE LENGTH("${column}") > ${length};`,
+        mergeOptions(this, {
+          table: this.name,
+          method: "pad()",
+          parameters: { columns, length, options },
+          returnDataFrom: "query",
+        }),
+      );
+      const overflowCount = Number(overflowResult![0].cnt);
+      if (overflowCount > 0) {
+        throw new Error(
+          `The column "${column}" has ${overflowCount} string(s) exceeding the target length of ${length}. The pad() method does not truncate. Shorten the strings first or use a larger target length.`,
         );
       }
     }

--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -2789,9 +2789,9 @@ export default class SimpleTable extends Simple {
   /**
    * Pads the strings in the specified column to a target length.
    *
-   * Only string values are padded. `null` values remain `null`, and non-string
-   * values (other than `null`) are left unchanged. Strings longer than the
-   * target length are truncated to fit.
+   * The column must contain string (VARCHAR) values. An error is thrown if the
+   * column is of a different type. `null` values remain `null`. An error is
+   * thrown if any string value exceeds the target length.
    *
    * @param column - The column name containing strings to be padded.
    * @param length - The target length of the padded strings.
@@ -2799,6 +2799,8 @@ export default class SimpleTable extends Simple {
    * @param options.side - Which side to pad. `'start'` (default) or `'end'`.
    * @param options.char - The character to use for padding. Defaults to `'0'`.
    * @returns A promise that resolves when the padding operation is complete.
+   * @throws {Error} If the column is not of string (VARCHAR) type.
+   * @throws {Error} If any string value in the column exceeds the target length.
    * @category Updating Data
    *
    * @example
@@ -2834,6 +2836,26 @@ export default class SimpleTable extends Simple {
     length: number,
     options: { side?: "start" | "end"; char?: string } = {},
   ): Promise<void> {
+    // Validate column type is string
+    const allTypes = await this.getTypes();
+    if (allTypes[column] !== "VARCHAR") {
+      throw new Error(
+        `The column "${column}" is of type ${
+          allTypes[column]
+        }. The pad() method only works with string (VARCHAR) columns. Please convert the column to string first with the .convert() method.`,
+      );
+    }
+
+    // Validate no string value exceeds the target length
+    const values = await this.getValues(column);
+    for (const val of values) {
+      if (val !== null && typeof val === "string" && val.length > length) {
+        throw new Error(
+          `The string "${val}" in column "${column}" has length ${val.length}, which exceeds the target length ${length}.`,
+        );
+      }
+    }
+
     await queryDB(
       this,
       padQuery(this.name, column, length, options),

--- a/src/methods/padQuery.ts
+++ b/src/methods/padQuery.ts
@@ -7,8 +7,9 @@ export default function padQuery(
   const side = options.side ?? "start";
   const char = options.char ?? "0";
 
-  // Wrap the padding character in single quotes for SQL
-  const paddedChar = `'${char}'`;
+  // Escape single quotes and wrap in single quotes for SQL
+  const escapedChar = char.replace(/'/g, "''");
+  const paddedChar = `'${escapedChar}'`;
   const func = side === "start" ? "LPAD" : "RPAD";
 
   let query = "";

--- a/src/methods/padQuery.ts
+++ b/src/methods/padQuery.ts
@@ -1,0 +1,18 @@
+export default function padQuery(
+  table: string,
+  column: string,
+  length: number,
+  options: { side?: "start" | "end"; char?: string },
+) {
+  const side = options.side ?? "start";
+  const char = options.char ?? "0";
+
+  // Wrap the padding character in single quotes for SQL
+  const paddedChar = `'${char}'`;
+
+  if (side === "start") {
+    return `UPDATE "${table}" SET "${column}" = LPAD("${column}", ${length}, ${paddedChar});`;
+  } else {
+    return `UPDATE "${table}" SET "${column}" = RPAD("${column}", ${length}, ${paddedChar});`;
+  }
+}

--- a/src/methods/padQuery.ts
+++ b/src/methods/padQuery.ts
@@ -2,15 +2,15 @@ export default function padQuery(
   table: string,
   columns: string[],
   length: number,
-  options: { side?: "start" | "end"; char?: string },
+  options: { method?: "left" | "right"; char?: string },
 ) {
-  const side = options.side ?? "start";
+  const method = options.method ?? "left";
   const char = options.char ?? "0";
 
   // Escape single quotes and wrap in single quotes for SQL
   const escapedChar = char.replace(/'/g, "''");
   const paddedChar = `'${escapedChar}'`;
-  const func = side === "start" ? "LPAD" : "RPAD";
+  const func = method === "left" ? "LPAD" : "RPAD";
 
   let query = "";
   for (const column of columns) {

--- a/src/methods/padQuery.ts
+++ b/src/methods/padQuery.ts
@@ -1,6 +1,6 @@
 export default function padQuery(
   table: string,
-  column: string,
+  columns: string[],
   length: number,
   options: { side?: "start" | "end"; char?: string },
 ) {
@@ -9,10 +9,13 @@ export default function padQuery(
 
   // Wrap the padding character in single quotes for SQL
   const paddedChar = `'${char}'`;
+  const func = side === "start" ? "LPAD" : "RPAD";
 
-  if (side === "start") {
-    return `UPDATE "${table}" SET "${column}" = LPAD("${column}", ${length}, ${paddedChar});`;
-  } else {
-    return `UPDATE "${table}" SET "${column}" = RPAD("${column}", ${length}, ${paddedChar});`;
+  let query = "";
+  for (const column of columns) {
+    query +=
+      `\nUPDATE "${table}" SET "${column}" = ${func}("${column}", ${length}, ${paddedChar});`;
   }
+
+  return query;
 }

--- a/test/unit/methods/pad.test.ts
+++ b/test/unit/methods/pad.test.ts
@@ -122,15 +122,15 @@ Deno.test("should throw error when string exceeds target length", async () => {
   const sdb = new SimpleDB();
   const table = sdb.newTable();
   await table.loadArray([
-    { name: "Hello" },
+    { name: "Hi" },
     { name: "World!!" },
-    { name: "Short" },
+    { name: "OK" },
   ]);
 
   await assertRejects(
-    () => table.pad("name", 5),
+    () => table.pad("name", 3),
     Error,
-    'The string "World!!" in column "name" has length 7, which exceeds the target length 5.',
+    'Column "name" contains strings with length 7, which exceeds the target length 3.',
   );
   await sdb.done();
 });
@@ -184,7 +184,7 @@ Deno.test("should throw error when string exceeds target length 0", async () => 
   await assertRejects(
     () => table.pad("text", 0),
     Error,
-    'The string "Hello" in column "text" has length 5, which exceeds the target length 0.',
+    'Column "text" contains strings with length 5, which exceeds the target length 0.',
   );
   await sdb.done();
 });
@@ -261,6 +261,97 @@ Deno.test("should handle multiple rows with null values", async () => {
     { id: "0023" },
     { id: null },
     { id: "0045" },
+  ]);
+  await sdb.done();
+});
+
+// Multi-column tests
+
+Deno.test("should pad multiple columns at once", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { id: "1", code: "AB" },
+    { id: "23", code: "C" },
+  ]);
+
+  await table.pad(["id", "code"], 4, { side: "start", char: "-" });
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { id: "---1", code: "--AB" },
+    { id: "--23", code: "---C" },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should pad multiple columns with right padding", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { name: "A", label: "X" },
+    { name: "BC", label: "YZ" },
+  ]);
+
+  await table.pad(["name", "label"], 4, { side: "end", char: "*" });
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { name: "A***", label: "X***" },
+    { name: "BC**", label: "YZ**" },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should throw error when one of multiple columns is not string type", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { name: "Alice", age: 30 },
+    { name: "Bob", age: 25 },
+  ]);
+
+  await assertRejects(
+    () => table.pad(["name", "age"], 5),
+    Error,
+    'The column "age" is of type DOUBLE',
+  );
+  await sdb.done();
+});
+
+Deno.test("should throw error when one of multiple columns exceeds target length", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { short: "A", long: "ThisIsWayTooLong" },
+    { short: "B", long: "OK" },
+  ]);
+
+  await assertRejects(
+    () => table.pad(["short", "long"], 5),
+    Error,
+    'Column "long" contains strings with length 16, which exceeds the target length 5.',
+  );
+  await sdb.done();
+});
+
+Deno.test("should pad all null column without error", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { id: null },
+    { id: null },
+  ]);
+
+  await table.pad("id", 3);
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { id: null },
+    { id: null },
   ]);
   await sdb.done();
 });

--- a/test/unit/methods/pad.test.ts
+++ b/test/unit/methods/pad.test.ts
@@ -118,7 +118,7 @@ Deno.test("should throw error when column is not string type", async () => {
   await sdb.done();
 });
 
-Deno.test("should throw error when string exceeds target length", async () => {
+Deno.test("should truncate strings exceeding target length", async () => {
   const sdb = new SimpleDB();
   const table = sdb.newTable();
   await table.loadArray([
@@ -127,11 +127,15 @@ Deno.test("should throw error when string exceeds target length", async () => {
     { name: "OK" },
   ]);
 
-  await assertRejects(
-    () => table.pad("name", 3),
-    Error,
-    'Column "name" contains strings with length 7, which exceeds the target length 3.',
-  );
+  await table.pad("name", 3);
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { name: "0Hi" },
+    { name: "Wor" },
+    { name: "0OK" },
+  ]);
   await sdb.done();
 });
 
@@ -173,7 +177,7 @@ Deno.test("should handle empty strings", async () => {
   await sdb.done();
 });
 
-Deno.test("should throw error when string exceeds target length 0", async () => {
+Deno.test("should truncate strings when target length is 0", async () => {
   const sdb = new SimpleDB();
   const table = sdb.newTable();
   await table.loadArray([
@@ -181,11 +185,14 @@ Deno.test("should throw error when string exceeds target length 0", async () => 
     { text: "World" },
   ]);
 
-  await assertRejects(
-    () => table.pad("text", 0),
-    Error,
-    'Column "text" contains strings with length 5, which exceeds the target length 0.',
-  );
+  await table.pad("text", 0);
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { text: "" },
+    { text: "" },
+  ]);
   await sdb.done();
 });
 
@@ -321,7 +328,7 @@ Deno.test("should throw error when one of multiple columns is not string type", 
   await sdb.done();
 });
 
-Deno.test("should throw error when one of multiple columns exceeds target length", async () => {
+Deno.test("should truncate long strings in multi-column pad", async () => {
   const sdb = new SimpleDB();
   const table = sdb.newTable();
   await table.loadArray([
@@ -329,11 +336,14 @@ Deno.test("should throw error when one of multiple columns exceeds target length
     { short: "B", long: "OK" },
   ]);
 
-  await assertRejects(
-    () => table.pad(["short", "long"], 5),
-    Error,
-    'Column "long" contains strings with length 16, which exceeds the target length 5.',
-  );
+  await table.pad(["short", "long"], 5, { side: "start", char: "-" });
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { short: "----A", long: "ThisI" },
+    { short: "----B", long: "---OK" },
+  ]);
   await sdb.done();
 });
 

--- a/test/unit/methods/pad.test.ts
+++ b/test/unit/methods/pad.test.ts
@@ -1,0 +1,281 @@
+import { assertEquals } from "@std/assert";
+import SimpleDB from "../../../src/class/SimpleDB.ts";
+
+Deno.test("should left-pad strings to target length with default zero", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { id: "1" },
+    { id: "23" },
+    { id: "456" },
+  ]);
+
+  await table.pad("id", 3);
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { id: "001" },
+    { id: "023" },
+    { id: "456" },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should right-pad strings to target length", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { code: "123" },
+    { code: "45" },
+    { code: "6" },
+  ]);
+
+  await table.pad("code", 5, { side: "end" });
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { code: "12300" },
+    { code: "45000" },
+    { code: "60000" },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should left-pad with custom character", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { id: "1" },
+    { id: "2" },
+  ]);
+
+  await table.pad("id", 4, { side: "start", char: "-" });
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { id: "---1" },
+    { id: "---2" },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should right-pad with custom character", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { code: "AB" },
+    { code: "CD" },
+  ]);
+
+  await table.pad("code", 5, { side: "end", char: "*" });
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { code: "AB***" },
+    { code: "CD***" },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should handle null values by leaving them as null", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { id: "1" },
+    { id: null },
+    { id: "3" },
+  ]);
+
+  await table.pad("id", 3);
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { id: "001" },
+    { id: null },
+    { id: "003" },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should handle columns with mixed types (strings and non-strings)", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.setTypes({
+    id: "string",
+    value: "integer",
+  });
+  await table.loadArray([
+    { id: "1", value: 10 },
+    { id: "2", value: 20 },
+  ]);
+
+  await table.pad("id", 5);
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { id: "00001", value: 10 },
+    { id: "00002", value: 20 },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should truncate strings longer than target length", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { name: "Hello" },
+    { name: "World!!" },
+    { name: "Short" },
+  ]);
+
+  await table.pad("name", 5);
+
+  const data = await table.getData();
+
+  // LPAD/RPAD truncate strings longer than the target length
+  assertEquals(data, [
+    { name: "Hello" },
+    { name: "World" },
+    { name: "Short" },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should handle column names with spaces", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { "user id": "1" },
+    { "user id": "23" },
+  ]);
+
+  await table.pad("user id", 4);
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { "user id": "0001" },
+    { "user id": "0023" },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should handle empty strings", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { id: "" },
+    { id: "a" },
+  ]);
+
+  await table.pad("id", 3);
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { id: "000" },
+    { id: "00a" },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should handle padding to length 0", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { text: "Hello" },
+    { text: "World" },
+  ]);
+
+  await table.pad("text", 0);
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { text: "" },
+    { text: "" },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should handle padding with multi-character fill string", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { id: "1" },
+  ]);
+
+  await table.pad("id", 5, { side: "start", char: "ab" });
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { id: "abab1" },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should pad with default side being start", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { code: "ABC" },
+  ]);
+
+  await table.pad("code", 6);
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { code: "000ABC" },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should pad with default char being zero", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { value: "123" },
+  ]);
+
+  await table.pad("value", 5, { side: "end" });
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { value: "12300" },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should handle multiple rows with null values", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { id: "1" },
+    { id: null },
+    { id: "23" },
+    { id: null },
+    { id: "4567" },
+  ]);
+
+  await table.pad("id", 4, { side: "start", char: "0" });
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { id: "0001" },
+    { id: null },
+    { id: "0023" },
+    { id: null },
+    { id: "4567" },
+  ]);
+  await sdb.done();
+});

--- a/test/unit/methods/pad.test.ts
+++ b/test/unit/methods/pad.test.ts
@@ -365,3 +365,25 @@ Deno.test("should pad all null column without error", async () => {
   ]);
   await sdb.done();
 });
+
+// SQL injection guard
+
+Deno.test("should safely handle single quote in padding character", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadArray([
+    { id: "1" },
+    { id: "23" },
+  ]);
+
+  await table.pad("id", 5, { side: "start", char: "'" });
+
+  const data = await table.getData();
+
+  // Single quote is properly escaped in SQL, LPAD pads to length 5
+  assertEquals(data, [
+    { id: "''''1" },
+    { id: "'''23" },
+  ]);
+  await sdb.done();
+});

--- a/test/unit/methods/pad.test.ts
+++ b/test/unit/methods/pad.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import SimpleDB from "../../../src/class/SimpleDB.ts";
 
 Deno.test("should left-pad strings to target length with default zero", async () => {
@@ -102,30 +102,23 @@ Deno.test("should handle null values by leaving them as null", async () => {
   await sdb.done();
 });
 
-Deno.test("should handle columns with mixed types (strings and non-strings)", async () => {
+Deno.test("should throw error when column is not string type", async () => {
   const sdb = new SimpleDB();
   const table = sdb.newTable();
-  await table.setTypes({
-    id: "string",
-    value: "integer",
-  });
   await table.loadArray([
-    { id: "1", value: 10 },
-    { id: "2", value: 20 },
+    { id: 1 },
+    { id: 2 },
   ]);
 
-  await table.pad("id", 5);
-
-  const data = await table.getData();
-
-  assertEquals(data, [
-    { id: "00001", value: 10 },
-    { id: "00002", value: 20 },
-  ]);
+  await assertRejects(
+    () => table.pad("id", 5),
+    Error,
+    'The column "id" is of type DOUBLE',
+  );
   await sdb.done();
 });
 
-Deno.test("should truncate strings longer than target length", async () => {
+Deno.test("should throw error when string exceeds target length", async () => {
   const sdb = new SimpleDB();
   const table = sdb.newTable();
   await table.loadArray([
@@ -134,16 +127,11 @@ Deno.test("should truncate strings longer than target length", async () => {
     { name: "Short" },
   ]);
 
-  await table.pad("name", 5);
-
-  const data = await table.getData();
-
-  // LPAD/RPAD truncate strings longer than the target length
-  assertEquals(data, [
-    { name: "Hello" },
-    { name: "World" },
-    { name: "Short" },
-  ]);
+  await assertRejects(
+    () => table.pad("name", 5),
+    Error,
+    'The string "World!!" in column "name" has length 7, which exceeds the target length 5.',
+  );
   await sdb.done();
 });
 
@@ -185,7 +173,7 @@ Deno.test("should handle empty strings", async () => {
   await sdb.done();
 });
 
-Deno.test("should handle padding to length 0", async () => {
+Deno.test("should throw error when string exceeds target length 0", async () => {
   const sdb = new SimpleDB();
   const table = sdb.newTable();
   await table.loadArray([
@@ -193,14 +181,11 @@ Deno.test("should handle padding to length 0", async () => {
     { text: "World" },
   ]);
 
-  await table.pad("text", 0);
-
-  const data = await table.getData();
-
-  assertEquals(data, [
-    { text: "" },
-    { text: "" },
-  ]);
+  await assertRejects(
+    () => table.pad("text", 0),
+    Error,
+    'The string "Hello" in column "text" has length 5, which exceeds the target length 0.',
+  );
   await sdb.done();
 });
 
@@ -263,7 +248,7 @@ Deno.test("should handle multiple rows with null values", async () => {
     { id: null },
     { id: "23" },
     { id: null },
-    { id: "4567" },
+    { id: "45" },
   ]);
 
   await table.pad("id", 4, { side: "start", char: "0" });
@@ -275,7 +260,7 @@ Deno.test("should handle multiple rows with null values", async () => {
     { id: null },
     { id: "0023" },
     { id: null },
-    { id: "4567" },
+    { id: "0045" },
   ]);
   await sdb.done();
 });

--- a/test/unit/methods/pad.test.ts
+++ b/test/unit/methods/pad.test.ts
@@ -31,7 +31,7 @@ Deno.test("should right-pad strings to target length", async () => {
     { code: "6" },
   ]);
 
-  await table.pad("code", 5, { side: "end" });
+  await table.pad("code", 5, { method: "right" });
 
   const data = await table.getData();
 
@@ -51,7 +51,7 @@ Deno.test("should left-pad with custom character", async () => {
     { id: "2" },
   ]);
 
-  await table.pad("id", 4, { side: "start", char: "-" });
+  await table.pad("id", 4, { method: "left", char: "-" });
 
   const data = await table.getData();
 
@@ -70,7 +70,7 @@ Deno.test("should right-pad with custom character", async () => {
     { code: "CD" },
   ]);
 
-  await table.pad("code", 5, { side: "end", char: "*" });
+  await table.pad("code", 5, { method: "right", char: "*" });
 
   const data = await table.getData();
 
@@ -118,7 +118,7 @@ Deno.test("should throw error when column is not string type", async () => {
   await sdb.done();
 });
 
-Deno.test("should truncate strings exceeding target length", async () => {
+Deno.test("should throw error when strings exceed target length", async () => {
   const sdb = new SimpleDB();
   const table = sdb.newTable();
   await table.loadArray([
@@ -127,15 +127,11 @@ Deno.test("should truncate strings exceeding target length", async () => {
     { name: "OK" },
   ]);
 
-  await table.pad("name", 3);
-
-  const data = await table.getData();
-
-  assertEquals(data, [
-    { name: "0Hi" },
-    { name: "Wor" },
-    { name: "0OK" },
-  ]);
+  await assertRejects(
+    () => table.pad("name", 3),
+    Error,
+    'The column "name" has 1 string(s) exceeding the target length of 3',
+  );
   await sdb.done();
 });
 
@@ -177,12 +173,12 @@ Deno.test("should handle empty strings", async () => {
   await sdb.done();
 });
 
-Deno.test("should truncate strings when target length is 0", async () => {
+Deno.test("should pad to length 0 when all strings are empty", async () => {
   const sdb = new SimpleDB();
   const table = sdb.newTable();
   await table.loadArray([
-    { text: "Hello" },
-    { text: "World" },
+    { text: "" },
+    { text: "" },
   ]);
 
   await table.pad("text", 0);
@@ -203,7 +199,7 @@ Deno.test("should handle padding with multi-character fill string", async () => 
     { id: "1" },
   ]);
 
-  await table.pad("id", 5, { side: "start", char: "ab" });
+  await table.pad("id", 5, { method: "left", char: "ab" });
 
   const data = await table.getData();
 
@@ -213,7 +209,7 @@ Deno.test("should handle padding with multi-character fill string", async () => 
   await sdb.done();
 });
 
-Deno.test("should pad with default side being start", async () => {
+Deno.test("should pad with default method being left", async () => {
   const sdb = new SimpleDB();
   const table = sdb.newTable();
   await table.loadArray([
@@ -237,7 +233,7 @@ Deno.test("should pad with default char being zero", async () => {
     { value: "123" },
   ]);
 
-  await table.pad("value", 5, { side: "end" });
+  await table.pad("value", 5, { method: "right" });
 
   const data = await table.getData();
 
@@ -258,7 +254,7 @@ Deno.test("should handle multiple rows with null values", async () => {
     { id: "45" },
   ]);
 
-  await table.pad("id", 4, { side: "start", char: "0" });
+  await table.pad("id", 4, { method: "left", char: "0" });
 
   const data = await table.getData();
 
@@ -282,7 +278,7 @@ Deno.test("should pad multiple columns at once", async () => {
     { id: "23", code: "C" },
   ]);
 
-  await table.pad(["id", "code"], 4, { side: "start", char: "-" });
+  await table.pad(["id", "code"], 4, { method: "left", char: "-" });
 
   const data = await table.getData();
 
@@ -301,7 +297,7 @@ Deno.test("should pad multiple columns with right padding", async () => {
     { name: "BC", label: "YZ" },
   ]);
 
-  await table.pad(["name", "label"], 4, { side: "end", char: "*" });
+  await table.pad(["name", "label"], 4, { method: "right", char: "*" });
 
   const data = await table.getData();
 
@@ -328,7 +324,7 @@ Deno.test("should throw error when one of multiple columns is not string type", 
   await sdb.done();
 });
 
-Deno.test("should truncate long strings in multi-column pad", async () => {
+Deno.test("should throw error when one column has overflow in multi-column pad", async () => {
   const sdb = new SimpleDB();
   const table = sdb.newTable();
   await table.loadArray([
@@ -336,14 +332,11 @@ Deno.test("should truncate long strings in multi-column pad", async () => {
     { short: "B", long: "OK" },
   ]);
 
-  await table.pad(["short", "long"], 5, { side: "start", char: "-" });
-
-  const data = await table.getData();
-
-  assertEquals(data, [
-    { short: "----A", long: "ThisI" },
-    { short: "----B", long: "---OK" },
-  ]);
+  await assertRejects(
+    () => table.pad(["short", "long"], 5, { method: "left", char: "-" }),
+    Error,
+    'The column "long" has 1 string(s) exceeding the target length of 5',
+  );
   await sdb.done();
 });
 
@@ -376,7 +369,7 @@ Deno.test("should safely handle single quote in padding character", async () => 
     { id: "23" },
   ]);
 
-  await table.pad("id", 5, { side: "start", char: "'" });
+  await table.pad("id", 5, { method: "left", char: "'" });
 
   const data = await table.getData();
 


### PR DESCRIPTION
## Summary

Adds a  method to  for padding string values to a target length using DuckDB's / functions.

## Changes

### 
- Generates  statements using / for one or more columns

###  —  method
- **Signature:** 
- Supports **left** (, default) and **right** () padding
- Default fill character is 
- Validates columns are  type (throws if not)
- Validates no string exceeds target length via efficient  DuckDB query (no silent truncation)
-  values remain 

### Tests (19 tests)
- Left/right padding with default and custom characters
- Multi-column support
- Null handling
- Non-string column error
- Overflow error (string exceeds target length)
- Edge cases: empty strings, column names with spaces, all-null columns, multi-character fill strings

Fixes #28