### PR TITLE
Normalize log* methods: add table name to logUniques() and standardize "Table" casing

### DIFF
--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -6709,9 +6709,9 @@ export default class SimpleTable extends Simple {
       this.connection === undefined ||
       !(await this.sdb.hasTable(this.name))
     ) {
-      console.log(`\ntable ${this.name}: no data`);
+      console.log(`\nTable ${this.name}: no data`);
     } else {
-      console.log(`\ntable ${this.name}:`);
+      console.log(`\nTable ${this.name}:`);
       console.table(await getDescription(this));
     }
   }
@@ -6729,7 +6729,7 @@ export default class SimpleTable extends Simple {
    * ```
    */
   async logProjections(): Promise<this> {
-    console.log(`\ntable ${this.name} projections:`);
+    console.log(`\nTable ${this.name} projections:`);
     console.log(this.projections);
     return await this;
   }
@@ -6747,7 +6747,7 @@ export default class SimpleTable extends Simple {
    * ```
    */
   async logTypes(): Promise<this> {
-    console.log(`\ntable ${this.name} types:`);
+    console.log(`\nTable ${this.name} types:`);
     console.log(await this.getTypes());
     return await this;
   }
@@ -6779,7 +6779,7 @@ export default class SimpleTable extends Simple {
     options: { stringify?: boolean } = {},
   ): Promise<this> {
     const values = await this.getUniques(column);
-    console.log(`\nUnique values in ${column}:`);
+    console.log(`\nTable ${this.name} — unique values in ${column}:`);
     if (options.stringify) {
       console.log(JSON.stringify(values, null, 2));
     } else {


### PR DESCRIPTION
## Summary

Normalize the nine `log*` methods on `SimpleTable` so they all consistently use the `Table ${this.name}` prefix in their console output.

## Changes

### 1. Add table name to `logUniques()`
- **Before:** `\nUnique values in ${column}:`
- **After:** `\nTable ${this.name} — unique values in ${column}:`

### 2. Normalize casing to uppercase `Table` in three methods
| Method | Before | After |
|---|---|---|
| `logDescription()` | `table ${this.name}:` | `Table ${this.name}:` |
| `logProjections()` | `table ${this.name} projections:` | `Table ${this.name} projections:` |
| `logTypes()` | `table ${this.name} types:` | `Table ${this.name} types:` |

## Acceptance Criteria

- [x] `logUniques()` output includes the table name
- [x] `logDescription()`, `logProjections()`, `logTypes()` use uppercase `Table`
- [x] All nine `log*` methods now consistently use `Table ${this.name}` prefix
- [x] `deno lint`, `deno fmt`, `deno check` pass
- [x] All 833 existing tests still pass

Fixes https://github.com/nshiab/simple-data-analysis-core/issues/29