### PR TITLE
fix: fill() preserves original row order in output

### DIFF
--- a/src/methods/fill.ts
+++ b/src/methods/fill.ts
@@ -25,28 +25,26 @@ export default async function fill(
 
   if (options.interpolate || options.interpolateBy) {
     const cols = stringToArray(columns);
-    let orderCol: string;
-    let excludeList: string;
-    if (options.interpolateBy) {
-      orderCol = options.interpolateBy;
-      excludeList = cols.join(", ");
-    } else {
-      await simpleTable.addRowNumber(tempRowCol);
-      orderCol = tempRowCol;
-      excludeList = [`"${tempRowCol}"`, ...cols].join(", ");
-    }
+
+    // Always add temp row number to preserve original row order in output
+    await simpleTable.addRowNumber(tempRowCol);
+
+    // Use interpolateBy for the window function's ORDER BY (correct interpolation math),
+    // but always order final output by tempRowCol to preserve input row order
+    const windowOrderCol = options.interpolateBy ?? tempRowCol;
+    const excludeList = [`"${tempRowCol}"`, ...cols].join(", ");
     const overClause = categories.length > 0
       ? `(PARTITION BY ${categories.map((d) => `"${d}"`).join(", ")})`
       : `()`;
     const selectList = cols
       .map(
         (col) =>
-          `fill(${col} ORDER BY "${orderCol}") OVER ${overClause} as ${col}`,
+          `fill(${col} ORDER BY "${windowOrderCol}") OVER ${overClause} as ${col}`,
       )
       .join(", ");
     await queryDB(
       simpleTable,
-      `CREATE OR REPLACE TABLE "${simpleTable.name}" AS SELECT * EXCLUDE(${excludeList}), ${selectList} FROM "${simpleTable.name}" ORDER BY "${orderCol}";`,
+      `CREATE OR REPLACE TABLE "${simpleTable.name}" AS SELECT * EXCLUDE(${excludeList}), ${selectList} FROM "${simpleTable.name}" ORDER BY "${tempRowCol}";`,
       mergeOptions(simpleTable, {
         table: simpleTable.name,
         method: "fill()",
@@ -76,14 +74,18 @@ export default async function fill(
       }),
     );
   } else {
+    // Simple path: add temp row number and order by it to preserve input row order
+    await simpleTable.addRowNumber(tempRowCol);
+    const cols = stringToArray(columns);
+    const excludeList = [`"${tempRowCol}"`, ...cols].join(", ");
+    const selectList = cols
+      .map(
+        (col) => `COALESCE(${col}, LAG(${col} IGNORE NULLS) OVER()) as ${col}`,
+      )
+      .join(", ");
     await queryDB(
       simpleTable,
-      stringToArray(columns)
-        .map(
-          (col) =>
-            `CREATE OR REPLACE TABLE "${simpleTable.name}" AS SELECT * EXCLUDE(${col}), COALESCE(${col}, LAG(${col} IGNORE NULLS) OVER()) as ${col} FROM "${simpleTable.name}";`,
-        )
-        .join("\n"),
+      `CREATE OR REPLACE TABLE "${simpleTable.name}" AS SELECT * EXCLUDE(${excludeList}), ${selectList} FROM "${simpleTable.name}" ORDER BY "${tempRowCol}";`,
       mergeOptions(simpleTable, {
         table: simpleTable.name,
         method: "fill()",

--- a/test/unit/methods/fill.test.ts
+++ b/test/unit/methods/fill.test.ts
@@ -189,12 +189,13 @@ Deno.test("should interpolate proportionally to a non-equidistant x column withi
     categories: "group",
   });
   const data = await table.getData();
+  // Row order is preserved (not reordered by group)
   assertEquals(data, [
     { group: "a", x: 0, y: 0 },
-    { group: "b", x: 0, y: 10 },
     { group: "a", x: 1, y: 2 },
-    { group: "b", x: 2, y: 18 },
     { group: "a", x: 3, y: 6 },
+    { group: "b", x: 0, y: 10 },
+    { group: "b", x: 2, y: 18 },
     { group: "b", x: 10, y: 50 },
   ]);
   await sdb.done();
@@ -233,5 +234,59 @@ Deno.test("should throw when interpolateBy is set and interpolate is false", asy
     error?.message,
     "interpolate cannot be false when interpolateBy is set.",
   );
+  await sdb.done();
+});
+
+// Row order preservation tests
+
+Deno.test("should preserve row order after fill() with categories and interpolation", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable("data");
+  const input = [
+    { id: 1, group: "a", val: 10 },
+    { id: 2, group: "b", val: 100 },
+    { id: 3, group: "a", val: null },
+    { id: 4, group: "b", val: null },
+    { id: 5, group: "a", val: 20 },
+    { id: 6, group: "b", val: 200 },
+  ];
+  await table.loadArray(input);
+  await table.fill("val", { categories: "group", interpolate: true });
+  const data = await table.getData();
+  // Row order must match input order (by id)
+  assertEquals(data.map((r) => r.id), [1, 2, 3, 4, 5, 6]);
+  assertEquals(data, [
+    { id: 1, group: "a", val: 10 },
+    { id: 2, group: "b", val: 100 },
+    { id: 3, group: "a", val: 15 },
+    { id: 4, group: "b", val: 150 },
+    { id: 5, group: "a", val: 20 },
+    { id: 6, group: "b", val: 200 },
+  ]);
+  await sdb.done();
+});
+
+Deno.test("should preserve row order after simple fill() with no options", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable("data");
+  const input = [
+    { id: 1, val: "A" },
+    { id: 2, val: null },
+    { id: 3, val: null },
+    { id: 4, val: "B" },
+    { id: 5, val: null },
+  ];
+  await table.loadArray(input);
+  await table.fill("val");
+  const data = await table.getData();
+  // Row order must match input order (by id)
+  assertEquals(data.map((r) => r.id), [1, 2, 3, 4, 5]);
+  assertEquals(data, [
+    { id: 1, val: "A" },
+    { id: 2, val: "A" },
+    { id: 3, val: "A" },
+    { id: 4, val: "B" },
+    { id: 5, val: "B" },
+  ]);
   await sdb.done();
 });

--- a/test/unit/methods/fill.test.ts
+++ b/test/unit/methods/fill.test.ts
@@ -290,3 +290,33 @@ Deno.test("should preserve row order after simple fill() with no options", async
   ]);
   await sdb.done();
 });
+
+Deno.test("should preserve row order after fill() with categories and interpolateBy", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable("data");
+  const input = [
+    { id: 1, group: "a", x: 0, y: 0 },
+    { id: 2, group: "b", x: 0, y: 10 },
+    { id: 3, group: "a", x: 1, y: null }, // 1/3 between 0 and 3 -> 2
+    { id: 4, group: "b", x: 2, y: null }, // 2/10 between 0 and 10 -> 18
+    { id: 5, group: "a", x: 3, y: 6 },
+    { id: 6, group: "b", x: 10, y: 50 },
+  ];
+  await table.loadArray(input);
+  await table.fill("y", {
+    categories: "group",
+    interpolateBy: "x",
+  });
+  const data = await table.getData();
+  // Row order must match input order (by id)
+  assertEquals(data.map((r) => r.id), [1, 2, 3, 4, 5, 6]);
+  assertEquals(data, [
+    { id: 1, group: "a", x: 0, y: 0 },
+    { id: 2, group: "b", x: 0, y: 10 },
+    { id: 3, group: "a", x: 1, y: 2 },
+    { id: 4, group: "b", x: 2, y: 18 },
+    { id: 5, group: "a", x: 3, y: 6 },
+    { id: 6, group: "b", x: 10, y: 50 },
+  ]);
+  await sdb.done();
+});


### PR DESCRIPTION
## Summary

`fill()` was reordering rows in two of its three SQL code paths. This fix ensures the output always matches the input row order.

## Changes

### `src/methods/fill.ts`
- **Path 1 (interpolate/interpolateBy):** Always add `tempRowCol`. Use `interpolateBy` inside `fill() OVER (ORDER BY ...)` for correct interpolation math, but `ORDER BY tempRowCol` in the final `SELECT` to preserve row order.
- **Path 3 (simple fill, no categories/interpolation):** Add `tempRowCol` and `ORDER BY tempRowCol` (was non-deterministic with no `ORDER BY`).
- Path 2 (categories only) already preserved row order ✓

### `test/unit/methods/fill.test.ts`
- Fixed existing test that asserted the broken (reordered) output
- Added test: verify row order preserved after `fill()` with categories + interpolation
- Added test: verify row order preserved after simple `fill()` (no options)

All 835 tests pass.

Fixes #49
