### PR TITLE
feat: allow numeric shortcut for decimals in SimpleTable.round()

### DIFF
--- a/llm.md
+++ b/llm.md
@@ -3116,7 +3116,7 @@ Rounds numeric values in specified columns.
 ##### Signature
 
 ```typescript
-async round(columns: string | string[], options?: { decimals?: number; method?: "round" | "ceiling" | "floor" }): Promise<void>;
+async round(columns: string | string[], options?: number | { decimals?: number; method?: "round" | "ceiling" | "floor" }): Promise<void>;
 ```
 
 ##### Parameters
@@ -3155,6 +3155,11 @@ await table.round("column1", { method: "floor" });
 ```ts
 // Round 'columnA' and 'columnB' values to 1 decimal place using ceiling method
 await table.round(["columnA", "columnB"], { decimals: 1, method: "ceiling" });
+```
+
+```ts
+// Round 'column1' values to 2 decimal places using the shorthand
+await table.round("column1", 2);
 ```
 
 #### `updateColumn`

--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -3297,17 +3297,29 @@ export default class SimpleTable extends Simple {
    * // Round 'columnA' and 'columnB' values to 1 decimal place using ceiling method
    * await table.round(["columnA", "columnB"], { decimals: 1, method: "ceiling" });
    * ```
+   *
+   * @example
+   * ```ts
+   * // Round 'column1' values to 2 decimal places using the shorthand
+   * await table.round("column1", 2);
+   * ```
    */
   async round(
     columns: string | string[],
-    options: {
-      decimals?: number;
-      method?: "round" | "ceiling" | "floor";
-    } = {},
+    options:
+      | number
+      | {
+        decimals?: number;
+        method?: "round" | "ceiling" | "floor";
+      } = {},
   ): Promise<void> {
+    const optionsNormalized = typeof options === "number"
+      ? { decimals: options }
+      : options;
+
     await queryDB(
       this,
-      roundQuery(this.name, stringToArray(columns), options),
+      roundQuery(this.name, stringToArray(columns), optionsNormalized),
       mergeOptions(this, {
         table: this.name,
         method: "round()",

--- a/test/unit/methods/round.test.ts
+++ b/test/unit/methods/round.test.ts
@@ -100,3 +100,43 @@ Deno.test("should round multiple columns", async () => {
 
   await sdb.done();
 });
+
+Deno.test("should round using the numeric shorthand", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadData(["test/data/files/dataManyDecimals.csv"]);
+  await table.selectColumns(["key1"]);
+
+  await table.round("key1", 2);
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { key1: 1.04 },
+    { key1: 3.24 },
+    { key1: 8.1 },
+    { key1: 10 },
+  ]);
+
+  await sdb.done();
+});
+
+Deno.test("should round to 0 decimals using the numeric shorthand", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable();
+  await table.loadData(["test/data/files/dataManyDecimals.csv"]);
+  await table.selectColumns(["key1"]);
+
+  await table.round("key1", 0);
+
+  const data = await table.getData();
+
+  assertEquals(data, [
+    { key1: 1 },
+    { key1: 3 },
+    { key1: 8 },
+    { key1: 10 },
+  ]);
+
+  await sdb.done();
+});


### PR DESCRIPTION
Fixes #34\n\n## Summary\n\nAdded a numeric shorthand for the second parameter of `SimpleTable.round()`, allowing users to pass a number of decimals directly instead of an options object.\n\n## Changes\n\n- Updated `SimpleTable.round()` to accept `number | { decimals?: number; method?: "round" | "ceiling" | "floor" }`.\n- Added normalization logic: a number input is treated as `{ decimals: n }` (method defaults to `"round"`).\n- Updated JSDoc with a shorthand example.\n- Added unit tests for numeric shorthand (positive and zero decimals).\n- Verified that existing object-based calls still work.\n\n## Usage Example\n\n```ts\n// New shorthand\nawait table.round("column1", 2);\n\n// Still works\nawait table.round("column1", { decimals: 2 });\n```\n\n---\n🤖 _Nael's Pi coding agent_