### PR TITLE
feat: add randomPoint method to SimpleTable

### DIFF
--- a/llm.md
+++ b/llm.md
@@ -5893,6 +5893,39 @@ await table.centroid("centerPoint");
 await table.centroid("areaCentroid", { column: "areaGeom" });
 ```
 
+#### `randomPoint`
+
+Generates a random point within the geometries of a specified column.
+
+##### Signature
+
+```typescript
+async randomPoint(newColumn: string, nbPointsToTry: number, options?: { column?: string }): Promise<void>;
+```
+
+##### Parameters
+
+- **`newColumn`**: The name of the new column where the random points will be
+  stored.
+- **`nbPointsToTry`**: The number of points to generate within the bounding box
+  of each geometry to find one that is within the geometry itself.
+- **`options`**: An optional object with configuration options:
+- **`options.column`**: The name of the column storing the geometries within
+  which the random points will be generated. If omitted, the method will
+  automatically attempt to find a geometry column.
+
+##### Examples
+
+```ts
+// Generate a random point for each geometry in the default column, trying 100 points
+await table.randomPoint("randomPoint", 100);
+```
+
+```ts
+// Generate a random point for each geometry in a specific column named 'areaGeom', trying 50 points
+await table.randomPoint("pointInArea", 50, { column: "areaGeom" });
+```
+
 #### `distance`
 
 Computes the distance between geometries in two specified columns. By default,

--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -46,6 +46,7 @@ import removeQuery from "../methods/removeQuery.ts";
 import normalizeQuery from "../methods/normalizeQuery.ts";
 import rollingQuery from "../methods/rollingQuery.ts";
 import distanceQuery from "../methods/distanceQuery.ts";
+import randomPointQuery from "../methods/randomPointQuery.ts";
 import getGeoData from "../methods/getGeoData.ts";
 import writeGeoData from "../helpers/writeGeoData.ts";
 import splitSpread from "../methods/splitSpread.ts";
@@ -6173,6 +6174,50 @@ export default class SimpleTable extends Simple {
         table: this.name,
         method: "centroid()",
         parameters: { column, newColumn },
+      }),
+    );
+    this.projections[newColumn] = this.projections[column];
+  }
+
+  /**
+   * Generates a random point within the geometries of a specified column.
+   *
+   * @param newColumn - The name of the new column where the random points will be stored.
+   * @param nbPointsToTry - The number of points to generate within the bounding box of each geometry to find one that is within the geometry itself.
+   * @param options - An optional object with configuration options:
+   * @param options.column - The name of the column storing the geometries within which the random points will be generated. If omitted, the method will automatically attempt to find a geometry column.
+   *
+   * @example
+   * ```ts
+   * // Generate a random point for each geometry in the default column, trying 100 points
+   * await table.randomPoint("randomPoint", 100);
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Generate a random point for each geometry in a specific column named 'areaGeom', trying 50 points
+   * await table.randomPoint("pointInArea", 50, { column: "areaGeom" });
+   * ```
+   */
+  async randomPoint(
+    newColumn: string,
+    nbPointsToTry: number,
+    options: { column?: string } = {},
+  ): Promise<void> {
+    if (typeof nbPointsToTry !== "number" || nbPointsToTry < 1) {
+      throw new Error("nbPointsToTry must be a number greater than 0");
+    }
+    const column = typeof options.column === "string"
+      ? options.column
+      : await findGeoColumn(this);
+
+    await queryDB(
+      this,
+      randomPointQuery(this.name, column, newColumn, nbPointsToTry),
+      mergeOptions(this, {
+        table: this.name,
+        method: "randomPoint()",
+        parameters: { column, newColumn, nbPointsToTry },
       }),
     );
     this.projections[newColumn] = this.projections[column];

--- a/src/methods/randomPointQuery.ts
+++ b/src/methods/randomPointQuery.ts
@@ -1,0 +1,25 @@
+export default function randomPointQuery(
+  table: string,
+  column: string,
+  newColumn: string,
+  nbPointsToTry: number,
+) {
+  return `INSTALL spatial;
+LOAD spatial;
+${
+    newColumn === column
+      ? ""
+      : `ALTER TABLE "${table}" ADD COLUMN "${newColumn}" GEOMETRY;`
+  }
+UPDATE "${table}" AS t
+SET "${newColumn}" = (
+    SELECT pt FROM (
+        SELECT ST_Point(
+            ST_XMin(t."${column}") + random() * (ST_XMax(t."${column}") - ST_XMin(t."${column}")),
+            ST_YMin(t."${column}") + random() * (ST_YMax(t."${column}") - ST_YMin(t."${column}"))
+        ) AS pt
+        FROM range(${nbPointsToTry})
+    ) WHERE ST_Within(pt, t."${column}")
+    LIMIT 1
+);`;
+}

--- a/test/unit/methods/randomPoint.test.ts
+++ b/test/unit/methods/randomPoint.test.ts
@@ -1,0 +1,29 @@
+import { assertEquals } from "@std/assert";
+import SimpleDB from "../../../src/class/SimpleDB.ts";
+
+Deno.test("should generate a random point in geometries", async () => {
+  const sdb = new SimpleDB();
+  const table = sdb.newTable("geodata");
+  await table.loadGeoData(
+    "test/geodata/files/CanadianProvincesAndTerritories.json",
+  );
+  // We can't easily test randomness, but we can test that the column is created and has points.
+  await table.randomPoint("randomPoint", 100);
+
+  const data = await table.getValues("randomPoint");
+
+  // Check if points are inside the original geometry
+  await table.inside("randomPoint", "geom", "isInside");
+  const isInside = await table.getValues("isInside");
+
+  // Check if we have 13 points (for 13 provinces/territories)
+  assertEquals(data.length, 13);
+
+  // Check that all values are not null and inside
+  for (let i = 0; i < data.length; i++) {
+    assertEquals(typeof data[i], "string");
+    assertEquals(isInside[i], true);
+  }
+
+  await sdb.done();
+});


### PR DESCRIPTION
This PR adds a new `randomPoint` method to `SimpleTable` that generates a random point within existing geometries using DuckDB's spatial extension. 

### Changes:
- Added `src/methods/randomPointQuery.ts` for the SQL logic.
- Added `randomPoint` method to `SimpleTable.ts`.
- Added unit tests in `test/unit/methods/randomPoint.test.ts`.
- Updated `llm.md` (autogenerated).

The implementation uses a robust subquery approach with `random()` and `ST_Within` because `ST_GeneratePoints` currently doesn't support using table columns as parameters in the DuckDB version used.