### PR TITLE
insertTables() now returns SimpleTable for method chaining

### DIFF
--- a/src/class/SimpleTable.ts
+++ b/src/class/SimpleTable.ts
@@ -958,7 +958,7 @@ export default class SimpleTable extends Simple {
    * @param tablesToInsert - The name(s) of the table(s) or SimpleTable instance(s) from which rows will be inserted.
    * @param options - An optional object with configuration options:
    * @param options.unifyColumns - A boolean indicating whether to unify the columns of the tables. If `true`, missing columns in a table will be filled with `NULL` values. Defaults to `false`.
-   * @returns A promise that resolves when the rows have been inserted.
+   * @returns The table itself, allowing for method chaining.
    * @category Importing Data
    *
    * @example
@@ -982,7 +982,7 @@ export default class SimpleTable extends Simple {
   async insertTables(
     tablesToInsert: SimpleTable | SimpleTable[],
     options: { unifyColumns?: boolean } = {},
-  ): Promise<void> {
+  ): Promise<this> {
     const array = Array.isArray(tablesToInsert)
       ? tablesToInsert
       : [tablesToInsert];
@@ -1070,6 +1070,8 @@ export default class SimpleTable extends Simple {
         }
       }
     }
+
+    return this;
   }
 
   /**

--- a/test/unit/methods/insertTables.test.ts
+++ b/test/unit/methods/insertTables.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import SimpleDB from "../../../src/class/SimpleDB.ts";
+import SimpleTable from "../../../src/class/SimpleTable.ts";
 
 Deno.test("should add rows from a table into another table", async () => {
   const sdb = new SimpleDB();
@@ -330,6 +331,19 @@ Deno.test("should add rows with tables with multiple geometry columns", async ()
       lon: "DOUBLE",
     },
   });
+  await sdb.done();
+});
+Deno.test("should return the table", async () => {
+  const sdb = new SimpleDB();
+  const table1 = sdb.newTable("table1");
+  await table1.loadData("test/data/files/data.json");
+
+  const table2 = sdb.newTable("table2");
+  await table2.loadData("test/data/files/data.json");
+
+  const result = await table1.insertTables(table2);
+  assertEquals(result instanceof SimpleTable, true);
+  assertEquals(result.name, "table1");
   await sdb.done();
 });
 Deno.test("should add rows to an empty table", async () => {


### PR DESCRIPTION
Closes #70

## Summary
- Changed `insertTables()` return type from `Promise<void>` to `Promise<this>`, enabling method chaining
- Added `return this;` at the end of the method
- Added a test verifying the returned value is a `SimpleTable` with the correct name