### PR TITLE
Add "all" option to removeTables()

### DIFF
--- a/src/class/SimpleDB.ts
+++ b/src/class/SimpleDB.ts
@@ -411,7 +411,7 @@ export default class SimpleDB<Table extends SimpleTable = SimpleTable>
   /**
    * Removes one or more tables from the database.
    *
-   * @param tables - A single table or an array of tables to remove, specified by name or as SimpleTable instances.
+   * @param tables - A single table or an array of tables to remove, specified by name or as SimpleTable instances. Pass `"all"` to remove all tables.
    * @returns A promise that resolves when the tables have been removed.
    * @category Table Management
    *
@@ -434,11 +434,21 @@ export default class SimpleDB<Table extends SimpleTable = SimpleTable>
    * // ... load data ...
    * await sdb.removeTables(employeesTable);
    * ```
+   *
+   * @example
+   * ```ts
+   * // Remove all tables
+   * await sdb.removeTables("all");
+   * ```
    */
   async removeTables(
     tables: Table | string | (Table | string)[],
   ): Promise<void> {
-    const tablesToBeRemoved = Array.isArray(tables) ? tables : [tables];
+    const tablesToBeRemoved = tables === "all"
+      ? [...this.tables]
+      : Array.isArray(tables)
+      ? tables
+      : [tables];
 
     await queryDB(
       this,

--- a/test/unit/class/SimpleDB.test.ts
+++ b/test/unit/class/SimpleDB.test.ts
@@ -142,6 +142,23 @@ Deno.test("should remove multiple tables as instances or strings", async () => {
   await sdb.done();
 });
 
+Deno.test("should remove all tables with 'all'", async () => {
+  const sdb = new SimpleDB();
+  const table1 = sdb.newTable("table1");
+  await table1.loadData(["test/data/files/data.json"]);
+  const table2 = sdb.newTable("table2");
+  await table2.loadData(["test/data/files/data.json"]);
+  const table3 = sdb.newTable("table3");
+  await table3.loadData(["test/data/files/data.json"]);
+
+  await sdb.removeTables("all");
+
+  const tables = await sdb.getTables();
+
+  assertEquals(tables, []);
+  await sdb.done();
+});
+
 Deno.test("should select one table as an instance", async () => {
   const sdb = new SimpleDB();
   const table1 = sdb.newTable("table1");


### PR DESCRIPTION
## Summary

- Adds `"all"` as a valid argument to `removeTables()`, which drops every table currently in the database
- Updates JSDoc with a new `@param` description and usage example
- Adds a test covering the new behaviour

Closes #69